### PR TITLE
Save data in main screen

### DIFF
--- a/get_data/get_series_data.py
+++ b/get_data/get_series_data.py
@@ -52,7 +52,8 @@ def get_current_series_mlb(team_name) -> str:
 
         mlb_series = series_summary
         return series_summary
-    except Exception:
+    except Exception as e:
+        print(f"Error getting MLB series information: {e}")
         return series_summary
 
 
@@ -87,7 +88,8 @@ def get_current_series_nhl(team_name) -> str:
             series_summary = f"Series Tied {away_series_wins} - {home_series_wins}"
 
         return series_summary
-    except Exception:
+    except Exception as e:
+        print(f"Error getting NHL series information: {e}")
         return series_summary
 
 
@@ -107,5 +109,6 @@ def get_current_series_nba(team_name) -> str:
             if game["homeTeam"]["teamName"] in team_name or game["awayTeam"]["teamName"] in team_name:
                 series_summary = game["seriesText"]
         return series_summary
-    except Exception:
+    except Exception as e:
+        print(f"Error getting NBA series information: {e}")
         return series_summary

--- a/helper_functions/scoreboard_helpers.py
+++ b/helper_functions/scoreboard_helpers.py
@@ -1,7 +1,6 @@
 """Module to Create and modify scoreboard GUI using FreeSimpleGUI."""
 
 import gc
-import json
 import subprocess
 import sys
 import time
@@ -9,6 +8,7 @@ import tkinter as tk
 from tkinter import font as tkFont
 
 import FreeSimpleGUI as sg  # type: ignore
+import orjson  # type: ignore
 
 import settings
 
@@ -64,8 +64,8 @@ def check_events(window: sg.Window, events, currently_playing=False) -> None:
         window.close()
         gc.collect()  # Clean up memory
         time.sleep(0.5)  # Give OS time to destroy the window
-        saved_data = json.dumps(settings.saved_data)
-        subprocess.Popen([sys.executable, "-m", "screens.main_screen", saved_data])
+        json_saved_data = orjson.dumps(settings.saved_data)
+        subprocess.Popen([sys.executable, "-m", "screens.main_screen", json_saved_data])
         sys.exit()
 
     elif 'Up' in events[0] and not settings.no_spoiler_mode:

--- a/helper_functions/scoreboard_helpers.py
+++ b/helper_functions/scoreboard_helpers.py
@@ -1,6 +1,7 @@
 """Module to Create and modify scoreboard GUI using FreeSimpleGUI."""
 
 import gc
+import json
 import subprocess
 import sys
 import time
@@ -63,7 +64,8 @@ def check_events(window: sg.Window, events, currently_playing=False) -> None:
         window.close()
         gc.collect()  # Clean up memory
         time.sleep(0.5)  # Give OS time to destroy the window
-        subprocess.Popen([sys.executable, "-m", "screens.main_screen", *sys.argv[1:]])
+        saved_data = json.dumps(settings.saved_data)
+        subprocess.Popen([sys.executable, "-m", "screens.main_screen", saved_data])
         sys.exit()
 
     elif 'Up' in events[0] and not settings.no_spoiler_mode:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nba_api
 nhl-api-py
 rapidfuzz
 types-requests
+orjson

--- a/screens/clock_screen.py
+++ b/screens/clock_screen.py
@@ -4,6 +4,7 @@
 
 import datetime
 import gc
+import json
 import subprocess
 import sys
 import time
@@ -63,7 +64,8 @@ def clock(window: sg.Window, message: str) -> list:
             window.close()
             gc.collect()  # Clean up memory
             time.sleep(0.5)  # Give OS time to destroy the window
-            subprocess.Popen([sys.executable, "-m", "screens.main_screen", *sys.argv[1:]])
+            saved_data = json.dumps(settings.saved_data)
+            subprocess.Popen([sys.executable, "-m", "screens.main_screen", saved_data])
             sys.exit()
 
         # Fetch to see if any teams have data and return to main loop displaying team info

--- a/screens/main_screen.py
+++ b/screens/main_screen.py
@@ -1,4 +1,5 @@
 import gc
+import json
 import os
 import platform
 import subprocess
@@ -24,7 +25,7 @@ from helper_functions.update import check_for_update, list_backups, restore_back
 from main import set_screen
 
 
-def main():
+def main(saved_data: dict) -> None:
     set_screen()
     update = False
     window_width = sg.Window.get_screen_size()[0]
@@ -216,7 +217,8 @@ def main():
             window.close()
             gc.collect()  # Clean up memory
             time.sleep(0.5)  # Give OS time to destroy the window
-            subprocess.Popen([sys.executable, "-m", "screens.not_playing_screen", *sys.argv[1:]])
+            json_saved_data = json.dumps(saved_data)
+            subprocess.Popen([sys.executable, "-m", "screens.not_playing_screen", json_saved_data])
             sys.exit()
 
         elif "Manual" in event:
@@ -244,4 +246,13 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 1:
+        try:
+            saved_data = json.loads(sys.argv[1])
+        except json.JSONDecodeError as e:
+            print("Invalid JSON argument:", e)
+            saved_data = {}
+    else:
+        print("No argument passed. Using default data.")
+        saved_data = {}
+    main(saved_data)

--- a/screens/not_playing_screen.py
+++ b/screens/not_playing_screen.py
@@ -1,6 +1,9 @@
 """Script to Display a Scoreboard for your Favorite Teams"""
 
+import copy
+import json
 import platform
+import sys
 import time
 import traceback
 from datetime import datetime, timedelta
@@ -28,9 +31,15 @@ from screens.currently_playing_screen import team_currently_playing
 #        Main Event Loop         #
 #                                #
 ##################################
-def main():
+def main(data_saved: dict) -> None:
+    """Main function to run the scoreboard application.
+
+    :param saved_data: Dictionary containing saved data for teams
+    """
+    # Initialize variables
     team_info = []
     teams_with_data = []
+    settings.saved_data = copy.deepcopy(data_saved)  # Load saved data from command line argument
     saved_data = settings.saved_data
     display_index = 0
     should_scroll = False
@@ -228,4 +237,13 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 1:
+        try:
+            saved_data = json.loads(sys.argv[1])
+        except json.JSONDecodeError as e:
+            print("Invalid JSON argument:", e)
+            saved_data = {}
+    else:
+        print("No argument passed. Using default data.")
+        saved_data = {}
+    main(saved_data)

--- a/screens/not_playing_screen.py
+++ b/screens/not_playing_screen.py
@@ -41,6 +41,7 @@ def main(data_saved: dict) -> None:
     teams_with_data = []
     settings.saved_data = copy.deepcopy(data_saved)  # Load saved data from command line argument
     saved_data = settings.saved_data
+    print("Saved Data:", saved_data)
     display_index = 0
     should_scroll = False
     display_clock = ticks_ms()  # Start Timer for Switching Display
@@ -107,7 +108,9 @@ def main(data_saved: dict) -> None:
                     elif teams[fetch_index][0] in saved_data and data is False:
                         print("Data is no longer available, checking if should display")
                         current_date = datetime.now()
-                        date_difference = current_date - saved_data[teams[fetch_index][0]][1]
+                        saved_str = saved_data[teams[fetch_index][0]][1]
+                        saved_datetime = datetime.fromisoformat(saved_str)
+                        date_difference = current_date - saved_datetime
                         # Check if 3 days have passed after data is no longer available
                         if date_difference <= timedelta(days=settings.HOW_LONG_TO_DISPLAY_TEAM):
                             print(f"It will display, time its been: {date_difference}")
@@ -129,6 +132,10 @@ def main(data_saved: dict) -> None:
                     display_first_time = False
                     print(f"\nUpdating Display for {teams[display_index][0]}")
                     reset_window_elements(window)
+
+                    if ("@" not in team_info[display_index]['above_score_txt'] and
+                        team_info[display_index]['above_score_txt'] != ""):
+                        window["above_score_txt"].update(font=(settings.FONT, settings.TOP_TXT_SIZE, "underline")),
 
                     should_scroll = will_text_fit_on_screen(team_info[display_index]['bottom_info'])
 

--- a/screens/not_playing_screen.py
+++ b/screens/not_playing_screen.py
@@ -108,8 +108,12 @@ def main(data_saved: dict) -> None:
                     elif teams[fetch_index][0] in saved_data and data is False:
                         print("Data is no longer available, checking if should display")
                         current_date = datetime.now()
-                        saved_str = saved_data[teams[fetch_index][0]][1]
-                        saved_datetime = datetime.fromisoformat(saved_str)
+                        saved_date = saved_data[teams[fetch_index][0]][1]
+                        if isinstance(saved_date, str):  # check if saved_date is a string, happens if went to main menu
+                            saved_datetime = datetime.fromisoformat(saved_date)  # convert string to datetime
+                        else:
+                            saved_datetime = saved_date  # already a datetime
+                        saved_datetime = datetime.fromisoformat(saved_date)
                         date_difference = current_date - saved_datetime
                         # Check if 3 days have passed after data is no longer available
                         if date_difference <= timedelta(days=settings.HOW_LONG_TO_DISPLAY_TEAM):


### PR DESCRIPTION
added a way to go back to main screen and still keep your saved team data. This if your team data is no longer being given by the API but its saved to display longer going back to the main screen will no longer erase it. This way when going from displaying teams to main screen back to displaying teams any team data that is no longer given by API's can still be displayed as its saved.